### PR TITLE
Issue#35 Sort Course Numbers in ComboBox

### DIFF
--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -39,7 +39,16 @@ export default function Search({ result }: { result: CourseResult[] }) {
           )
           .map((course) => course.courseNumber),
       ),
-    );
+    ).sort((a, b) => {
+      const numA = parseInt(a, 10);
+      const numB = parseInt(b, 10);
+
+      if (numA !== numB) {
+        return numA - numB;
+      } else {
+        return a.localeCompare(b);
+      }
+    });
   }, [result, selectedSubject]);
 
   const handleSemesterChange = useCallback((value: string) => {


### PR DESCRIPTION
# Description
Implemented sorting logic for the ComboBox on the home page to organize course numbers. Ensured courses without letters appear before those with (e.g., "30" before "30W") and sorted alphanumeric entries alphabetically (e.g., "22A" before "22B").

Fixes #35 