### PR TITLE
Issue#36 Add Course Numbers to Professor Page

### DIFF
--- a/src/app/professors/[id]/page.tsx
+++ b/src/app/professors/[id]/page.tsx
@@ -16,6 +16,9 @@ export default async function ProfessorPage({ params }: { params: { id: string }
     .where(eq(professorsCoursesTable.professorId, Number(params.id)))
     .innerJoin(coursesTable, eq(professorsCoursesTable.courseId, coursesTable.id));
 
+  console.log(courseResult);
+
+
   return (
     <div className="container mx-auto p-4">
       <div className="grid">
@@ -31,23 +34,31 @@ export default async function ProfessorPage({ params }: { params: { id: string }
               </div>
             </CardHeader>
             <CardContent className="mt-4">
-              <h2 className="text-2xl font-bold mb-4">Courses</h2>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {courseResult.map((result, index) => (
-                  <Card key={index} className="p-4">
-                    <CardHeader>
-                      <CardTitle className="text-lg font-semibold">
-                        {result.courses.subject} {result.courses.courseNumber}: {result.courses.title}
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <div className="mt-2">
-                        <StarRating rating={4.5} textColor="text-muted-foreground" />
-                      </div>
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
+              {courseResult.length > 0 ? (
+                <>
+                  <h2 className="text-2xl font-bold mb-4">Courses</h2>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {courseResult.map((result, index) => (
+                      <Card key={index} className="p-4">
+                        <CardHeader>
+                          <CardTitle className="text-lg font-semibold">
+                            {result.courses.subject} {result.courses.courseNumber}: {result.courses.title}
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                          <div className="mt-2">
+                            <StarRating rating={4.5} textColor="text-muted-foreground" />
+                          </div>
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <p className="text-muted-foreground text-center py-8">
+                  No courses found
+                </p>
+              )}
             </CardContent>
           </Card>
         ))}

--- a/src/app/professors/[id]/page.tsx
+++ b/src/app/professors/[id]/page.tsx
@@ -14,9 +14,7 @@ export default async function ProfessorPage({ params }: { params: { id: string }
     .select()
     .from(professorsCoursesTable)
     .where(eq(professorsCoursesTable.professorId, Number(params.id)))
-    .then((res) => {
-      return db.select().from(coursesTable).where(eq(coursesTable.id, res[0].courseId))
-    })
+    .innerJoin(coursesTable, eq(professorsCoursesTable.courseId, coursesTable.id));
 
   return (
     <div className="container mx-auto p-4">
@@ -34,10 +32,10 @@ export default async function ProfessorPage({ params }: { params: { id: string }
             </CardHeader>
             <CardContent className="mt-4">
               <h2 className="text-2xl font-bold mb-4">Courses</h2>
-              {courseResult.map((course) => (
-                <div key={course.id} className="mb-6 border-b pb-4 last:border-0">
-                  <p className="text-lg font-semibold mb-2">{course.title}</p>
-                  <p className="text-muted-foreground">{course.description}</p>
+              {courseResult.map((result, index) => (
+                <div key={index} className="mb-6 border-b pb-4 last:border-0">
+                  <p className="text-lg font-semibold mb-2">{result.courses.subject} {result.courses.courseNumber}: {result.courses.title}</p>
+                  <p className="text-muted-foreground">{result.courses.description}</p>
                   <div className="mt-2">
                     {/* The actual rating is a placeholder, the coursesTable scheme has not been updated to have starRating as a field */}
                     <StarRating rating={4.5} textColor="text-muted-foreground" />

--- a/src/app/professors/[id]/page.tsx
+++ b/src/app/professors/[id]/page.tsx
@@ -32,16 +32,22 @@ export default async function ProfessorPage({ params }: { params: { id: string }
             </CardHeader>
             <CardContent className="mt-4">
               <h2 className="text-2xl font-bold mb-4">Courses</h2>
-              {courseResult.map((result, index) => (
-                <div key={index} className="mb-6 border-b pb-4 last:border-0">
-                  <p className="text-lg font-semibold mb-2">{result.courses.subject} {result.courses.courseNumber}: {result.courses.title}</p>
-                  <p className="text-muted-foreground">{result.courses.description}</p>
-                  <div className="mt-2">
-                    {/* The actual rating is a placeholder, the coursesTable scheme has not been updated to have starRating as a field */}
-                    <StarRating rating={4.5} textColor="text-muted-foreground" />
-                  </div>
-                </div>
-              ))}
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {courseResult.map((result, index) => (
+                  <Card key={index} className="p-4">
+                    <CardHeader>
+                      <CardTitle className="text-lg font-semibold">
+                        {result.courses.subject} {result.courses.courseNumber}: {result.courses.title}
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="mt-2">
+                        <StarRating rating={4.5} textColor="text-muted-foreground" />
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
             </CardContent>
           </Card>
         ))}

--- a/src/app/professors/[id]/page.tsx
+++ b/src/app/professors/[id]/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { db } from "@/lib/db"
 import { coursesTable, professorsCoursesTable, professorsTable } from "@/lib/db/schema"
 import { eq } from "drizzle-orm"
+import Link from "next/link"
 
 export default async function ProfessorPage({ params }: { params: { id: string } }) {
   const professorResult = await db
@@ -16,9 +17,6 @@ export default async function ProfessorPage({ params }: { params: { id: string }
     .where(eq(professorsCoursesTable.professorId, Number(params.id)))
     .innerJoin(coursesTable, eq(professorsCoursesTable.courseId, coursesTable.id));
 
-  console.log(courseResult);
-
-
   return (
     <div className="container mx-auto p-4">
       <div className="grid">
@@ -27,7 +25,6 @@ export default async function ProfessorPage({ params }: { params: { id: string }
             <CardHeader className="bg-primary text-primary-foreground">
               <CardTitle className="text-4xl">{professor.name}</CardTitle>
               <p className="text-primary-foreground">{professor.department}</p>
-
               <div className="mt-2">
                 {/* The actual rating is a placeholder, the professorsTable scheme has not been updated to have starRating as a field */}
                 <StarRating rating={4.5} textColor="text-primary-foreground" />
@@ -41,12 +38,15 @@ export default async function ProfessorPage({ params }: { params: { id: string }
                     {courseResult.map((result, index) => (
                       <Card key={index} className="p-4">
                         <CardHeader>
-                          <CardTitle className="text-lg font-semibold">
-                            {result.courses.subject} {result.courses.courseNumber}: {result.courses.title}
-                          </CardTitle>
+                          <Link href={`/courses/${result.courses.id}`}>
+                            <CardTitle className="text-lg font-semibold hover:text-primary hover:underline">
+                              {result.courses.subject} {result.courses.courseNumber}: {result.courses.title}
+                            </CardTitle>
+                          </Link>
                         </CardHeader>
                         <CardContent>
                           <div className="mt-2">
+                            {/* The actual rating is a placeholder, the professorsTable scheme has not been updated to have starRating as a field */}
                             <StarRating rating={4.5} textColor="text-muted-foreground" />
                           </div>
                         </CardContent>


### PR DESCRIPTION
# Description
Professor page was only displaying the first course taught by that professor. Changed the query to show all courses taught. Displayed course numbers along side their title in individual cards.

Fixes #36 